### PR TITLE
Support temporary credentials

### DIFF
--- a/src/AwsTranscribe.ts
+++ b/src/AwsTranscribe.ts
@@ -7,11 +7,13 @@ import { StreamingClient } from "./StreamingClient"
 export class AwsTranscribe {
     private accessKeyId!: string
     private secretAccessKey!: string
+    private sessionToken: string | undefined
 
     constructor(config?: ClientConfig) {
         // get from environment if config not provided
         this.setAccessKeyId(config?.accessKeyId || process.env.AWS_ACCESS_KEY_ID)
         this.setSecretAccessKey(config?.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY)
+        this.setSessionToken(config?.sessionToken || process.env.AWS_SESSION_TOKEN)
     }
 
     private createPreSignedUrl(config: TranscribeStreamConfig) {
@@ -27,6 +29,7 @@ export class AwsTranscribe {
             {
                 key: this.accessKeyId,
                 secret: this.secretAccessKey,
+                sessionToken: this.sessionToken,
                 protocol: "wss",
                 expires: 15,
                 region: region,
@@ -50,5 +53,9 @@ export class AwsTranscribe {
         if (validateIsStringOtherwiseThrow(secretAccessKey, "secretAccessKey")) {
             this.secretAccessKey = secretAccessKey
         }
+    }
+
+    setSessionToken(sessionToken: string | undefined) {
+      this.sessionToken = sessionToken
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export type LANGUAGES = "en-US" | "en-AU" | "en-GB" | "fr-CA" | "fr-FR" | "es-US
 export interface ClientConfig {
     accessKeyId?: string
     secretAccessKey?: string
+    sessionToken?: string
 }
 
 export interface TranscribeStreamConfig {


### PR DESCRIPTION
When using temporary credentials (like AWS roles) we need to pass in an
extra parameter (session token) to the signing function to create a
valid signature. 

This is my first entry into TypeScript so looking for feedback how to make this more idiomatic.