### PR TITLE
adds showSpeakerLabel config parameter

### DIFF
--- a/src/AwsTranscribe.ts
+++ b/src/AwsTranscribe.ts
@@ -8,17 +8,23 @@ export class AwsTranscribe {
     private accessKeyId!: string
     private secretAccessKey!: string
     private sessionToken: string | undefined
+    private showSpeakerLabel?: boolean
 
     constructor(config?: ClientConfig) {
         // get from environment if config not provided
         this.setAccessKeyId(config?.accessKeyId || process.env.AWS_ACCESS_KEY_ID)
         this.setSecretAccessKey(config?.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY)
         this.setSessionToken(config?.sessionToken || process.env.AWS_SESSION_TOKEN)
+        this.setShowSpeakerLabel(config?.showSpeakerLabel || false)
     }
 
     private createPreSignedUrl(config: TranscribeStreamConfig) {
-        const { region, languageCode, sampleRate } = config
+        const { region, languageCode, sampleRate, showSpeakerLabel } = config
         const endpoint = "transcribestreaming." + region + ".amazonaws.com:8443"
+	let query = "language-code=" + languageCode + "&media-encoding=pcm&sample-rate=" + sampleRate
+	if (showSpeakerLabel) {
+	    query += '&show-speaker-label=true'
+	}
 
         return createPresignedURL(
             "GET",
@@ -33,7 +39,7 @@ export class AwsTranscribe {
                 protocol: "wss",
                 expires: 15,
                 region: region,
-                query: "language-code=" + languageCode + "&media-encoding=pcm&sample-rate=" + sampleRate,
+                query: query
             }
         )
     }
@@ -57,5 +63,9 @@ export class AwsTranscribe {
 
     setSessionToken(sessionToken: string | undefined) {
       this.sessionToken = sessionToken
+    }
+
+    setShowSpeakerLabel(showSpeakerLabel: boolean | false) {
+        this.showSpeakerLabel = showSpeakerLabel
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,14 @@ export interface ClientConfig {
     accessKeyId?: string
     secretAccessKey?: string
     sessionToken?: string
+    showSpeakerLabel?: boolean
 }
 
 export interface TranscribeStreamConfig {
     region: AVAILABLE_REGIONS
     languageCode: LANGUAGES
     sampleRate: number
+    showSpeakerLabel?: boolean
 }
 
 export interface PresignedUrlHeaders {


### PR DESCRIPTION
Adds support for the speaker labeling feature, as described here:
https://docs.aws.amazon.com/transcribe/latest/dg/diarization-streaming.html

usage:

client.createStreamingClient({
  region: 'us-west-2',
  sampleRate: 8000,
  languageCode: 'en-US',
  showSpeakerLabel: true
})